### PR TITLE
DM-51934: Addmigration scripts for schema version 7.0.0

### DIFF
--- a/doc/lsst.dax.apdb_migrate/migrations/cassandra/schema.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/cassandra/schema.rst
@@ -52,3 +52,15 @@ No additional parameters or packages are needed for this script.
 An example of migration::
 
     $ apdb-migrate-cassandra upgrade <host> <keyspace> schema_6.0.0
+
+Upgrade from 6.0.0 to 7.0.0
+===========================
+
+Migration script: `schema_7.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/cassandra/schema/schema_7.0.0.py>`_
+
+This migration adds ``glint_trail`` column to ``DiaSource`` table(s) (and ``DiaSourceChunks`` if it exists), initially set to ``NULL``.
+No additional parameters or packages are needed for this script.
+
+An example of migration::
+
+    $ apdb-migrate-cassandra upgrade <host> <keyspace> schema_7.0.0

--- a/doc/lsst.dax.apdb_migrate/migrations/sql/schema.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/sql/schema.rst
@@ -126,3 +126,15 @@ No additional parameters or packages are needed for this script.
 An example of migration::
 
     $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL schema_6.0.0
+
+Upgrade from 6.0.0 to 7.0.0
+===========================
+
+Migration script: `schema_7.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/sql/schema/schema_7.0.0.py>`_
+
+This migration adds ``glint_trail`` column to ``DiaSource`` table, initially set to ``NULL``.
+No additional parameters or packages are needed for this script.
+
+An example of migration::
+
+    $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL schema_7.0.0

--- a/migrations/cassandra/ApdbCassandraReplica/ApdbCassandraReplica_1.1.0.py
+++ b/migrations/cassandra/ApdbCassandraReplica/ApdbCassandraReplica_1.1.0.py
@@ -7,7 +7,7 @@ Create Date: 2025-04-14 16:19:00.653340
 
 import logging
 
-from lsst.dax.apdb_migrate.cassandra.context import Context, _Context
+from lsst.dax.apdb_migrate.cassandra.context import Context
 from lsst.dax.apdb_migrate.cassandra.table_schema import Column, TableSchema
 
 # revision identifiers, used by Alembic.
@@ -59,7 +59,7 @@ def downgrade() -> None:
     raise NotImplementedError()
 
 
-def _make_new_chunks_table(ctx: _Context, table_name: str) -> None:
+def _make_new_chunks_table(ctx: Context, table_name: str) -> None:
     """Create new replica chunk table based on the existing table schema.
 
     New table adds `apdb_replica_subchunk` column which also becomes a part of
@@ -86,7 +86,7 @@ def _make_new_chunks_table(ctx: _Context, table_name: str) -> None:
     ctx.update(table_ddl)
 
 
-def _update_frozen_config(ctx: _Context) -> None:
+def _update_frozen_config(ctx: Context) -> None:
     """Update configuration stored in metadata."""
     config = ctx.get_apdb_config()
     # Use default value for this parameter.

--- a/migrations/cassandra/schema/schema_7.0.0.py
+++ b/migrations/cassandra/schema/schema_7.0.0.py
@@ -1,0 +1,48 @@
+"""Migration script for schema 7.0.0.
+
+Revision ID: schema_7.0.0
+Revises: schema_6.0.0
+Create Date: 2025-07-25 13:59:21.723106
+"""
+
+import logging
+
+from lsst.dax.apdb_migrate.cassandra.context import Context
+
+# revision identifiers, used by Alembic.
+revision = "schema_7.0.0"
+down_revision = "schema_6.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade 'schema' tree from 6.0.0 to 7.0.0 (ticket DM-51934).
+
+    Summary of changes:
+      - Add boolean ``glint_trail`` column to DiaSource table(s).
+    """
+    with Context(revision) as ctx:
+        tables = ctx.schema.tables_for_schema("DiaSource")
+        if not tables:
+            raise RuntimeError("Cannot find DiaSource* tables in the database.")
+        for table in tables:
+            column_name = "glint_trail"
+            _LOG.info("Adding %s column to %s table", column_name, table)
+            query = f'ALTER TABLE "{ctx.keyspace}"."{table}" ADD "{column_name}" BOOLEAN'
+            ctx.update(query)
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision) as ctx:
+        tables = ctx.schema.tables_for_schema("DiaSource")
+        if not tables:
+            raise RuntimeError("Cannot find DiaSource* tables in the database.")
+        for table in tables:
+            column_name = "glint_trail"
+            _LOG.info("Dropping %s column from %s table", column_name, table)
+            query = f'ALTER TABLE "{ctx.keyspace}"."{table}" DROP "{column_name}"'
+            ctx.update(query)

--- a/migrations/sql/_alembic/script.py.mako
+++ b/migrations/sql/_alembic/script.py.mako
@@ -40,21 +40,11 @@ def upgrade() -> None:
     Summary of changes:
       - <Add summary of changes>.
     """
-    ctx = Context()
-
-    ${upgrades if upgrades else "raise NotImplementedError()"}
-
-    # Update metadata version.
-    tree, _, version = revision.partition("_")
-    ctx.apdb_meta.update_tree_version(tree, version)
+    with Context(revision) as ctx:
+        ${upgrades if upgrades else "raise NotImplementedError()"}
 
 
 def downgrade() -> None:
     """Undo changes applied in `upgrade`."""
-    ctx = Context()
-
-    ${downgrades if downgrades else "raise NotImplementedError()"}
-
-    # Update metadata version.
-    tree, _, version = down_revision.partition("_")
-    ctx.apdb_meta.update_tree_version(tree, version)
+    with Context(down_revision) as ctx:
+        ${downgrades if downgrades else "raise NotImplementedError()"}

--- a/migrations/sql/schema/schema_7.0.0.py
+++ b/migrations/sql/schema/schema_7.0.0.py
@@ -1,0 +1,46 @@
+"""Migration script for schema 7.0.0.
+
+Revision ID: schema_7.0.0
+Revises: schema_6.0.0
+Create Date: 2025-07-25 13:51:45.013540
+"""
+
+import logging
+
+import sqlalchemy
+from lsst.dax.apdb_migrate.sql.context import Context
+
+# revision identifiers, used by Alembic.
+revision = "schema_7.0.0"
+down_revision = "schema_6.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade 'schema' tree from 6.0.0 to 7.0.0 (ticket DM-51934).
+
+    Summary of changes:
+      - Add boolean ``glint_trail`` column to DiaSource table.
+    """
+    with Context(revision) as ctx:
+        table_name = "DiaSource"
+        table = ctx.get_table(table_name)
+        with ctx.batch_alter_table(table_name, copy_from=table) as batch_op:
+            # Add a column, NULL as default, do not fill.
+            column_name = "glint_trail"
+            _LOG.info("Adding %s column to %s table", column_name, table_name)
+            batch_op.add_column(sqlalchemy.Column(column_name, sqlalchemy.types.Boolean, nullable=True))
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision) as ctx:
+        table_name = "DiaSource"
+        table = ctx.get_table(table_name)
+        with ctx.batch_alter_table(table_name, copy_from=table) as batch_op:
+            column_name = "glint_trail"
+            _LOG.info("Dropping %s column from %s table", column_name, table_name)
+            batch_op.drop_column(column_name)

--- a/python/lsst/dax/apdb_migrate/cassandra/schema.py
+++ b/python/lsst/dax/apdb_migrate/cassandra/schema.py
@@ -1,0 +1,121 @@
+# This file is part of dax_apdb_migrate.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ["Schema"]
+
+from typing import Any, Protocol
+
+
+class Session(Protocol):
+    """Protocol for Cassandra Session, implementations will exist that just
+    print queries instead of executing them.
+    """
+
+    def execute(self, query: Any, parameters: Any) -> Any: ...
+
+
+class Schema:
+    """Class with methods for schema inspection.
+
+    Parameters
+    ----------
+    session : `cassandra.cluster.Session`
+        Database session.
+    keyspace : `str`
+        Name of Cassandra keyspace containing metadata table.
+    apdb_config : `dict`
+        Frozen part of APDB config from metadata.
+    """
+
+    def __init__(self, session: Session, keyspace: str, apdb_config: dict[str, Any]):
+        self._session = session
+        self._keyspace = keyspace
+        self._config = apdb_config
+
+    @property
+    def _has_replicas(self) -> bool:
+        return self._config["enable_replica"]
+
+    @property
+    def _has_partitioned_tables(self) -> bool:
+        return self._config["time_partition_tables"]
+
+    def all_tables(self) -> list[str]:
+        """Return names of all tables in the keyspace.
+
+        Returns
+        -------
+        items : `list` [`str`]
+            List of table names.
+        """
+        query = "SELECT table_name FROM system_schema.tables WHERE keyspace_name = %s"
+        result = self._session.execute(query, (self._keyspace,))
+        return [row[0] for row in result.all()]
+
+    def tables_for_schema(
+        self, schema_kind: str, *, include_replica: bool = True, include_obj_last: bool = False
+    ) -> list[str]:
+        """Return list of existing tables that share the same table schema.
+
+        Parameters
+        ----------
+        schema_kind : `str`
+            Table schema, one of "DiaObject", "DiaSource", "DiaForcedSorce".
+            Other kinds may exist that also can be specified.
+        include_replica : `bool`, optional
+            If `True` then include replica tables if replication is enabled
+            and table is replicated.
+        include_obj_last : `bool`, optional
+            If `True` and ``schema_kind`` is "DiaObject" then include
+            "DiaObjectLast" table in the result.
+
+        Returns
+        -------
+        names : `list` [`str`]
+            Names of the tables.
+        """
+        has_replicas = self._has_replicas
+        has_partitioned_tables = self._has_partitioned_tables
+
+        all_tables = set(self.all_tables())
+        check_tables = []
+        check_partitions = False
+        if schema_kind in ("DiaObject", "DiaSource", "DiaForcedSource"):
+            if has_replicas:
+                check_tables += [f"{schema_kind}Chunks", f"{schema_kind}Chunks2"]
+            if has_partitioned_tables:
+                check_partitions = True
+        if schema_kind == "DiaObject" and include_obj_last:
+            check_tables.append("DiaObjectLast")
+
+        # Try to check table name specifically.
+        check_tables.append(schema_kind)
+
+        result = [table for table in check_tables if table in all_tables]
+        if check_partitions:
+            for table in all_tables:
+                kind, _, part = table.partition("_")
+                if kind == schema_kind and part.isdigit():
+                    result.append(table)
+
+        return result

--- a/python/lsst/dax/apdb_migrate/cassandra/table_schema.py
+++ b/python/lsst/dax/apdb_migrate/cassandra/table_schema.py
@@ -26,7 +26,7 @@ __all__ = ("Column", "TableSchema")
 import dataclasses
 from typing import Any, NamedTuple, cast
 
-from .context import _Context
+from .context import Context
 
 
 @dataclasses.dataclass
@@ -80,7 +80,7 @@ class TableSchema:
     table_options: dict[str, Any]
 
     @classmethod
-    def from_table(cls, ctx: _Context, table_name: str) -> TableSchema:
+    def from_table(cls, ctx: Context, table_name: str) -> TableSchema:
         """Contruct table schema from its database definition."""
         # Get the list of columns from existing table.
         query = (

--- a/templates/generic/script.py.mako
+++ b/templates/generic/script.py.mako
@@ -40,21 +40,11 @@ def upgrade() -> None:
     Summary of changes:
       - <Add summary of changes>.
     """
-    ctx = Context()
-
-    ${upgrades if upgrades else "raise NotImplementedError()"}
-
-    # Update metadata version.
-    tree, _, version = revision.partition("_")
-    ctx.apdb_meta.update_tree_version(tree, version)
+    with Context(revision) as ctx:
+        ${upgrades if upgrades else "raise NotImplementedError()"}
 
 
 def downgrade() -> None:
     """Undo changes applied in `upgrade`."""
-    ctx = Context()
-
-    ${downgrades if downgrades else "raise NotImplementedError()"}
-
-    # Update metadata version.
-    tree, _, version = down_revision.partition("_")
-    ctx.apdb_meta.update_tree_version(tree, version)
+    with Context(down_revision) as ctx:
+        ${downgrades if downgrades else "raise NotImplementedError()"}


### PR DESCRIPTION
Added new class for Cassandra schema querying (getting the list of existing tables). Improved context managers for both SQL and Cassandra contexts.

## Checklist

- [X] added documentation for a new migration script
