### PR TITLE
DM-52287: Implement APDB migration for schema version 9.0.0

### DIFF
--- a/doc/lsst.dax.apdb_migrate/migrations/cassandra/ApdbCassandra.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/cassandra/ApdbCassandra.rst
@@ -52,3 +52,25 @@ This migration has to be applied after migration to ``schema_8.0.0``, it will fa
 An example command for applying the schema upgrade::
 
     $ apdb-migrate-cassandra upgrade <host> <keyspace> ApdbCassandra_1.0.0
+
+
+Upgrade from 1.0.0 to 1.1.0
+===========================
+
+Migration script: `ApdbCassandra_1.1.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/cassandra/ApdbCassandra/ApdbCassandra_1.1.0.py>`_
+
+``ApdbCassandra`` code was updated to use MJD TAI values for timestamp columns, and it is compatible with the schema that uses native timestamp types.
+MJD TAI timestamp columns were introduced with ``schema_9.0.0``.
+This migration only changes version of ``ApdCassandra`` tree in the metadata.
+
+Dependencies:
+
+- This migration requires revision ``schema_9.0.0`` in the database.
+
+An example command for applying the schema upgrade::
+
+    $ apdb-migrate-cassandra upgrade <host> <keyspace> ApdbCassandra_1.1.0
+
+.. note::
+    Cassandra database cannot be migrated to schema 9.0.0 from earlier versions.
+    The only way to use schema 9.0.0 with Cassandra is to create an empty database with that schema version, and should also produce ApdbCassandra 1.1.0 or later.

--- a/doc/lsst.dax.apdb_migrate/migrations/cassandra/schema.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/cassandra/schema.rst
@@ -81,7 +81,7 @@ An example of migration::
 Upgrade from 7.0.1 to 8.0.0
 ===========================
 
-Migration script: `schema_8.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/sql/schema/schema_8.0.0.py>`_
+Migration script: `schema_8.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/cassandra/schema/schema_8.0.0.py>`_
 
 Version 8.0.0 drops multiple columns from DiaSource and DiaObject tables, adding or renaming a small number of columns.
 Details of changes to the schema can be seen on `DM-50837 <https://rubinobs.atlassian.net/browse/DM-50837>`_.
@@ -97,3 +97,16 @@ Dependencies:
 An example of migration::
 
     $ apdb-migrate-cassandra upgrade <host> <keyspace> schema_8.0.0
+
+Upgrade from 8.0.0 to 9.0.0
+===========================
+
+Migration script: `schema_9.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/cassandra/schema/schema_9.0.0.py>`_
+
+Version 9.0.0 replaces native timestamp columns with MJD TAI (double precisiton).
+Columns are also renamed to have "MjdTai" suffix.
+
+.. note::
+    This migration exist as a placeholder, but it is not implemented.
+    Implementing it would require a lot of work and using external tools (dsbulk), and it would be very slow for reasonably-sized data.
+    The only way to use schema 9.0.0 with Cassandra is to create an empty database with that schema version.

--- a/doc/lsst.dax.apdb_migrate/migrations/sql/ApdbSql.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/sql/ApdbSql.rst
@@ -45,3 +45,20 @@ This migration has to be applied after migration to ``schema_8.0.0``, it will fa
 An example command for applying the schema upgrade::
 
     $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL ApdbSql_1.0.0
+
+Upgrade from 1.0.0 to 1.1.0
+===========================
+
+Migration script: `ApdbSql_1.1.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/sql/ApdbSql/ApdbSql_1.1.0.py>`_
+
+``ApdbSql`` code was updated to use MJD TAI values for timestamp columns, and it is compatible with the schema that uses native timestamp types.
+The actual change to the schema is performed by migration to ``schema_9.0.0``.
+This migration only changes version of ``ApdbSql`` tree in the metadata.
+
+Dependencies:
+
+- This migration requires revision ``schema_9.0.0`` in the database.
+
+An example command for applying the schema upgrade::
+
+    $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL ApdbSql_1.1.0

--- a/doc/lsst.dax.apdb_migrate/migrations/sql/schema.rst
+++ b/doc/lsst.dax.apdb_migrate/migrations/sql/schema.rst
@@ -165,3 +165,17 @@ Migration to ``ApdbSql_1.0.0`` should be performed after migration to ``schema_8
 An example of migration::
 
     $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL schema_8.0.0
+
+Upgrade from 8.0.0 to 9.0.0
+===========================
+
+Migration script: `schema_9.0.0.py <https://github.com/lsst-dm/dax_apdb_migrate/blob/main/migrations/sql/schema/schema_9.0.0.py>`_
+
+Version 9.0.0 replaces native timestamp columns with MJD TAI (double precisiton).
+Columns are also renamed to have "MjdTai" suffix.
+No additional parameters or packages are needed for this script.
+Migration to ``ApdbSql_1.1.0`` should be performed together and after migration to ``schema_9.0.0``.
+
+An example of migration::
+
+    $ apdb-migrate-sql upgrade -s SCHEMA_NAME $APDB_URL schema_9.0.0

--- a/migrations/cassandra/ApdbCassandra/ApdbCassandra_1.0.0.py
+++ b/migrations/cassandra/ApdbCassandra/ApdbCassandra_1.0.0.py
@@ -31,7 +31,7 @@ def upgrade() -> None:
     """
     with Context(revision) as ctx:
         try:
-            ctx.require_version("schema_8.0.0")
+            ctx.require_revision("schema_8.0.0")
         except ValueError as exc:
             raise ValueError("Schema version needs to be upgraded to 8.0.0") from exc
 

--- a/migrations/cassandra/ApdbCassandra/ApdbCassandra_1.1.0.py
+++ b/migrations/cassandra/ApdbCassandra/ApdbCassandra_1.1.0.py
@@ -1,0 +1,39 @@
+"""Migration script for ApdbCassandra 1.1.0.
+
+Revision ID: ApdbCassandra_1.1.0
+Revises: ApdbCassandra_1.0.0
+Create Date: 2025-08-27 14:38:54.455801
+"""
+
+import logging
+
+from lsst.dax.apdb_migrate.cassandra.context import Context
+
+# revision identifiers, used by Alembic.
+revision = "ApdbCassandra_1.1.0"
+down_revision = "ApdbCassandra_1.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade 'ApdbCassandra' tree from 1.0.0 to 1.1.0 (ticket DM-52287).
+
+    Summary of changes:
+
+        - Only the version is changed, but this migration depends on
+          `schema_9.0.0` and here we check that `schema` is at that version.
+    """
+    with Context(revision) as ctx:
+        try:
+            ctx.require_revision("schema_9.0.0")
+        except ValueError as exc:
+            raise ValueError("Schema version needs to be upgraded to 8.0.0") from exc
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision):
+        pass

--- a/migrations/cassandra/schema/schema_8.0.0.py
+++ b/migrations/cassandra/schema/schema_8.0.0.py
@@ -265,7 +265,7 @@ def upgrade() -> None:
         # ApdbCassandra_0.1.1 depends on a column which is renamed here, check
         # that that migration is already done.
         try:
-            ctx.require_version("ApdbCassandra_0.1.1")
+            ctx.require_revision("ApdbCassandra_0.1.1")
         except ValueError as exc:
             raise ValueError(
                 "ApdbCassandra version needs to be upgraded to 0.1.1 before this migration can be applied"

--- a/migrations/cassandra/schema/schema_9.0.0.py
+++ b/migrations/cassandra/schema/schema_9.0.0.py
@@ -1,0 +1,40 @@
+"""Migration script for schema 9.0.0.
+
+Revision ID: schema_9.0.0
+Revises: schema_8.0.0
+Create Date: 2025-08-27 14:38:32.139347
+"""
+
+import logging
+
+from lsst.dax.apdb_migrate.cassandra.context import Context
+
+# revision identifiers, used by Alembic.
+revision = "schema_9.0.0"
+down_revision = "schema_8.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade 'schema' tree from 8.0.0 to 9.0.0 (ticket DM-52287).
+
+    Summary of changes:
+      - Timestamp columns' type changed from native timestamp to MJD TAI.
+      - Columns have been renamed to have 'MjdTai' suffix.
+
+    NOTE: Schema upgrade for cassandra would require rewriting huge amount of
+    data and cannot be done without additional tools like ``dsbulk``. For now
+    the only way to use schema 9.0.0 with Cassandra is to create an empty
+    database with that schema version.
+    """
+    with Context(revision):
+        raise NotImplementedError("Schema upgrade from 8.0.0 to 9.0.0 is not implemented for Cassandra.")
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision):
+        raise NotImplementedError("Schema вщцтgrade from 9.0.0 to 8.0.0 is not implemented for Cassandra.")

--- a/migrations/sql/ApdbSql/ApdbSql_1.0.0.py
+++ b/migrations/sql/ApdbSql/ApdbSql_1.0.0.py
@@ -23,21 +23,17 @@ def upgrade() -> None:
 
     Summary of changes:
 
-        - Only version is changed, but this migration depends on`schema_8.0.0`
-          and here we check that `schema` is at that version.
+        - Only the version is changed, but this migration depends on
+          `schema_8.0.0` and here we check that `schema` is at that version.
 
     Note that it may be possible to use `depends_on` for this purpose, but
     creates a confusing migration tree, see alembic docs for details.
     """
     with Context(revision) as ctx:
-        schema_version = ctx.apdb_meta.get("version:schema")
-        if schema_version is None:
-            raise LookupError("Cannot find 'version:schema' in metadata.")
-        major_version = int(schema_version.split(".")[0])
-        if major_version < 8:
-            raise ValueError(
-                f"Schema version needs to be upgraded to 8.0.0, current version: {schema_version}"
-            )
+        try:
+            ctx.require_revision("schema_8.0.0")
+        except ValueError as exc:
+            raise ValueError("Schema version needs to be upgraded to 8.0.0") from exc
 
 
 def downgrade() -> None:

--- a/migrations/sql/ApdbSql/ApdbSql_1.1.0.py
+++ b/migrations/sql/ApdbSql/ApdbSql_1.1.0.py
@@ -1,0 +1,39 @@
+"""Migration script for ApdbSql 1.1.0.
+
+Revision ID: ApdbSql_1.1.0
+Revises: ApdbSql_1.0.0
+Create Date: 2025-08-25 11:39:22.417946
+"""
+
+import logging
+
+from lsst.dax.apdb_migrate.sql.context import Context
+
+# revision identifiers, used by Alembic.
+revision = "ApdbSql_1.1.0"
+down_revision = "ApdbSql_1.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+def upgrade() -> None:
+    """Upgrade 'ApdbSql' tree from 1.0.0 to 1.1.0 (ticket DM-52287).
+
+    Summary of changes:
+
+        - Only the version is changed, but this migration depends on
+          `schema_9.0.0` and here we check that `schema` is at that version.
+    """
+    with Context(revision) as ctx:
+        try:
+            ctx.require_revision("schema_9.0.0")
+        except ValueError as exc:
+            raise ValueError("Schema version needs to be upgraded to 8.0.0") from exc
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision):
+        pass

--- a/migrations/sql/schema/schema_9.0.0.py
+++ b/migrations/sql/schema/schema_9.0.0.py
@@ -1,0 +1,262 @@
+"""Migration script for schema 9.0.0.
+
+Revision ID: schema_9.0.0
+Revises: schema_8.0.0
+Create Date: 2025-08-25 11:38:59.590064
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, NamedTuple, overload
+
+import sqlalchemy
+from astropy.time import Time
+from lsst.dax.apdb_migrate.sql.context import Context
+from lsst.utils.iteration import chunk_iterable
+
+# revision identifiers, used by Alembic.
+revision = "schema_9.0.0"
+down_revision = "schema_8.0.0"
+branch_labels = None
+depends_on = None
+
+_LOG = logging.getLogger(__name__)
+
+
+class _Column(NamedTuple):
+    """Column name before/after migration and mullable flag."""
+
+    old_name: str
+    new_name: str
+    nullable: bool
+    new_type: type = sqlalchemy.types.Double
+
+    def downgrade(self) -> _Column:
+        """Make a copy of column definition used for downgrade."""
+        if self.new_type is sqlalchemy.types.Double:
+            return _Column(self.new_name, self.old_name, self.nullable, sqlalchemy.types.TIMESTAMP)
+        else:
+            # Just in case someone applies downgrade() more than once.
+            return self
+
+    @overload
+    def convert_value(self, value: None) -> None: ...
+
+    @overload
+    def convert_value(self, value: datetime) -> float: ...
+
+    @overload
+    def convert_value(self, value: float) -> datetime: ...
+
+    def convert_value(self, value: datetime | float | None) -> datetime | float | None:
+        if value is None:
+            return None
+        if self.new_type is sqlalchemy.types.Double:
+            time = Time(value, format="datetime", scale="tai")
+            return float(time.mjd)
+        else:
+            time = Time(value, format="mjd", scale="tai")
+            # This returns naive datetiem, this is how it was done in ApdbSql.
+            return time.datetime
+
+
+class _Index(NamedTuple):
+    """Index description."""
+
+    name: str
+    columns: tuple[str, ...]
+
+
+# Column name and nullable flag.
+COLUMNS: dict[str, tuple[_Column, ...]] = {
+    "DiaObject": (
+        _Column("validityStart", "validityStartMjdTai", False),
+        _Column("validityEnd", "validityEndMjdTai", True),
+    ),
+    "DiaObjectChunks": (_Column("validityStart", "validityStartMjdTai", False),),
+    "DiaSource": (
+        _Column("ssObjectReassocTime", "ssObjectReassocTimeMjdTai", True),
+        _Column("time_processed", "timeProcessedMjdTai", False),
+        _Column("time_withdrawn", "timeWithdrawnMjdTai", True),
+    ),
+    "DiaForcedSource": (
+        _Column("time_processed", "timeProcessedMjdTai", False),
+        _Column("time_withdrawn", "timeWithdrawnMjdTai", True),
+    ),
+}
+
+OLD_PK_COLUMNS = {
+    "DiaObject": ("diaObjectId", "validityStart"),
+    "DiaObjectChunks": ("diaObjectId", "validityStart"),
+    "DiaSource": ("diaSourceId",),
+    "DiaForcedSource": ("diaObjectId", "visit", "detector"),
+}
+
+NEW_PK_COLUMNS = {
+    "DiaObject": ("diaObjectId", "validityStartMjdTai"),
+    "DiaObjectChunks": ("diaObjectId", "validityStartMjdTai"),
+    "DiaSource": ("diaSourceId",),
+    "DiaForcedSource": ("diaObjectId", "visit", "detector"),
+}
+
+# Indices that need to be replaced.
+INDICES = {
+    "DiaObject": {
+        _Index("IDX_DiaObject_validityStart", ("validityStart",)): _Index(
+            "IDX_DiaObject_validityStartMjdTai", ("validityStartMjdTai",)
+        ),
+    },
+}
+
+
+def upgrade() -> None:
+    """Upgrade 'schema' tree from 8.0.0 to 9.0.0 (ticket DM-52287).
+
+    Summary of changes:
+      - Timestamp columns' type changed from native timestamp to MJD TAI.
+      - Columns have been renamed to have 'MjdTai' suffix.
+      - This also means that some indices and PKs need to be recreated.
+
+    The migration is quite slow as it updates big tables. There maybe more
+    optimal way by re-calculating timestamps using SQL functions, but it is
+    backend-specific and not implemented at this point.
+    """
+    with Context(revision) as ctx:
+        _migrate_default(ctx, True)
+
+
+def downgrade() -> None:
+    """Undo changes applied in `upgrade`."""
+    with Context(down_revision) as ctx:
+        _migrate_default(ctx, False)
+
+
+def _migrate_default(ctx: Context, upgrade: bool) -> None:
+    column_type = sqlalchemy.types.Double if upgrade else sqlalchemy.types.TIMESTAMP
+
+    for table, columns in COLUMNS.items():
+        # Some tables may be missing
+        try:
+            ctx.get_table(table)
+        except sqlalchemy.exc.NoSuchTableError:
+            if table == "DiaObjectChunks":
+                continue
+            raise
+
+        _LOG.info("Processing table %s", table)
+
+        if not upgrade:
+            columns = tuple(column.downgrade() for column in columns)
+
+        # Create new columns first as nullable.
+        with ctx.batch_alter_table(table) as batch_op:
+            _LOG.info("Adding new columns: %s", [column.new_name for column in columns])
+            for column in columns:
+                batch_op.add_column(sqlalchemy.Column(column.new_name, column.new_type, nullable=True))
+
+        # Populate new columns with data from old ones.
+        if upgrade:
+            pk_columns = OLD_PK_COLUMNS[table]
+        else:
+            pk_columns = NEW_PK_COLUMNS[table]
+        _LOG.info("Populating new columns with data")
+        _populate(ctx, table, columns, column_type, pk_columns, upgrade)
+
+        # Drop existing indices and columns
+        with ctx.batch_alter_table(table) as batch_op:
+            # May need to drop PK as well.
+            if not set(pk_columns).isdisjoint(column.old_name for column in columns):
+                # Postgres drops PK when the column is dropped, but sqlite
+                # complains that column cannot be dropped if it's in PK. The
+                # workaround is to create PK with new columns, but Postgres
+                # also requires existing PK to be dropped first, and in sqlite
+                # we do not even have name for PK constraint, so it cannot be
+                # dropped explicitly.
+                pk_name = f"{table}_pkey"
+                if ctx.is_postgres:
+                    _LOG.info("Dropping %s constraint", pk_name)
+                    batch_op.drop_constraint(pk_name)
+                _LOG.info("Add %s constraint", pk_name)
+                new_pk_columns = NEW_PK_COLUMNS[table] if upgrade else OLD_PK_COLUMNS[table]
+                batch_op.create_primary_key(pk_name, list(new_pk_columns))
+
+            # Drop indices.
+            for old_index, new_index in INDICES.get(table, {}).items():
+                if not upgrade:
+                    old_index, new_index = new_index, old_index
+                _LOG.info("Dropping index %s", old_index.name)
+                batch_op.drop_index(old_index.name)
+                _LOG.info("Creating index %s", new_index.name)
+                batch_op.create_index(new_index.name, list(new_index.columns))
+
+            # Drop columns.
+            _LOG.info("Dropping columns %s", [column.old_name for column in columns])
+            for column in columns:
+                batch_op.drop_column(column.old_name)
+
+
+def _populate(
+    ctx: Context,
+    table_name: str,
+    columns: tuple[_Column, ...],
+    column_type: type,
+    pk_columns: tuple[str, ...],
+    upgrade: bool,
+) -> None:
+    table = ctx.get_table(table_name, reload=True)
+    pk_column_defs = [
+        sqlalchemy.schema.Column(name, table.columns[name].type, primary_key=True) for name in pk_columns
+    ]
+
+    # Create a temporary table which includes PK columns from original table
+    # a new column that we are going to poulate.
+    tmp_columns = pk_column_defs + [
+        sqlalchemy.schema.Column(column.new_name, column_type) for column in columns
+    ]
+    tmp_table = sqlalchemy.schema.Table(
+        f"_{table_name}_migration_tmp",
+        ctx.metadata,
+        *tmp_columns,
+        prefixes=["TEMPORARY"],
+        schema=sqlalchemy.schema.BLANK_SCHEMA,
+    )
+    tmp_table.create(ctx.bind)
+
+    # Select all records where timestamp is not None. Hopefully SQL database
+    # does not have too many records and we can fit everything into memory.
+    select_columns = [table.columns[name] for name in pk_columns]
+    select_columns += [table.columns[column.old_name] for column in columns]
+    query = sqlalchemy.select(*select_columns).select_from(table)
+
+    column_converters: list[Callable] = [lambda x: x] * len(pk_columns)
+    column_converters += [column.convert_value for column in columns]
+
+    def _convert_row(row: Any) -> tuple:
+        return tuple(converter(value) for converter, value in zip(column_converters, row, strict=True))
+
+    with ctx.reflection_bind() as bind:
+        result = bind.execute(query)
+        rows = [_convert_row(row) for row in result]
+
+    count = 0
+    for chunk in chunk_iterable(rows, 10_000):
+        insert = tmp_table.insert().values(chunk)
+        result = ctx.bind.execute(insert)
+        count += result.rowcount
+    _LOG.info("Inserted %s rows into a temporary table for %s", count, table_name)
+
+    pk_where = sqlalchemy.and_(*(tmp_table.columns[name] == table.columns[name] for name in pk_columns))
+    if count > 0:
+        for column in columns:
+            _LOG.info("Populating column %s", column.new_name)
+            update = table.update().values(
+                {
+                    column.new_name: sqlalchemy.select(tmp_table.columns[column.new_name])
+                    .where(pk_where)
+                    .scalar_subquery()
+                }
+            )
+            result = bind.execute(update)

--- a/mypy.ini
+++ b/mypy.ini
@@ -9,6 +9,9 @@ disallow_incomplete_defs = True
 [mypy-cassandra.*]
 ignore_missing_imports = True
 
+[mypy-astropy.*]
+ignore_missing_imports = True
+
 [mypy-pandas.*]
 ignore_missing_imports = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ keywords = ["lsst"]
 dependencies = [
     "sqlalchemy",
     "alembic",
-    "lsst-utils"
+    "lsst-utils",
+    "astropy",
 ]
 dynamic = ["version"]
 

--- a/python/lsst/dax/apdb_migrate/cassandra/context.py
+++ b/python/lsst/dax/apdb_migrate/cassandra/context.py
@@ -242,8 +242,8 @@ class Context:
         """
         self.metadata.insert(f"version:{tree}", version)
 
-    def require_version(self, revision_str: str, exact: bool = False) -> None:
-        """Check that existing version of some tree satisfies requirement.
+    def require_revision(self, revision_str: str, exact: bool = False) -> None:
+        """Check that existing revision of some tree satisfies requirement.
 
         Parameters
         ----------

--- a/python/lsst/dax/apdb_migrate/sql/context.py
+++ b/python/lsst/dax/apdb_migrate/sql/context.py
@@ -31,6 +31,7 @@ import alembic
 import alembic.operations
 import sqlalchemy
 
+from .. import revision
 from .apdb_metadata import ApdbMetadata
 
 
@@ -158,3 +159,34 @@ class Context:
                 yield connection
         else:
             yield self.bind
+
+    def require_revision(self, revision_str: str, exact: bool = False) -> None:
+        """Check that existing version of some tree satisfies requirement.
+
+        Parameters
+        ----------
+        revision_str : `str`
+            Revision string in format "<tree>_<version>", e.g. "schema_1.2.3".
+        exact : `bool`
+            If True require exact match, othervise current version should be
+            greater or equal the one in ``revision``.
+        """
+        tree, version_req_str = revision.unpack_revision(revision_str)
+        if tree is None or version_req_str is None:
+            raise ValueError(f"Failed to parse revision string '{revision_str}'")
+        version_req = tuple(int(v) for v in version_req_str.split("."))
+
+        version_str = self.apdb_meta.get(f"version:{tree}")
+        if version_str is None:
+            raise LookupError(f"Cannot find 'version:{tree}' in metadata.")
+        version = tuple(int(v) for v in version_str.split("."))
+        if exact and version != version_req:
+            raise ValueError(
+                f"Existing version for {tree} ({version_str}) "
+                f"does not match requested version ({version_req_str})"
+            )
+        if not exact and version < version_req:
+            raise ValueError(
+                f"Existing version for {tree} ({version_str}) "
+                f"is older than requested version ({version_req_str})"
+            )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+astropy
 click
 sqlalchemy
 alembic


### PR DESCRIPTION
Added new scripts for schema_9.0.0, ApdbSql_1.10, and ApdbCassandra_1.1.0. schema_9.0.0 migration is not implemented for Cassandra.

## Checklist

- [X] added documentation for a new migration script
